### PR TITLE
Add documentation on helm3 + migration per skyscrapers/engineering#311

### DIFF
--- a/Concourse/README.md
+++ b/Concourse/README.md
@@ -329,8 +329,8 @@ jobs:
 
 ## helm v3
 
-At the time of writing the [concourse-helm-resource](https://github.com/linkyard/concourse-helm-resource/issues/135) is not compatible with Concourse.
-There is however a [concourse-helm3-resource](https://github.com/Typositoire/concourse-helm3-resource) forked from that repository that you can use. We are using that resource and are contributing actively to that resource.
+At the time of writing the [concourse-helm-resource](https://github.com/linkyard/concourse-helm-resource/issues/135) is not compatible with Helm v3.
+There is however a [concourse-helm3-resource](https://github.com/Typositoire/concourse-helm3-resource) forked from that repository that you can use. We are using that resource and are contributing actively to it.
 
 Example usage:
 

--- a/Concourse/README.md
+++ b/Concourse/README.md
@@ -270,7 +270,6 @@ pipelines:
     unpaused: true
 ```
 
-
 ## docker-image deprecation
 
 In the new Concourse 5.0.0 version, a new resource was released to track and upload Docker images to a registry, the [`registry-image-resource`](https://github.com/concourse/registry-image-resource). This new resource is intended to replace the current [`docker-image-resource`](https://github.com/concourse/docker-image-resource), as it's more lightweight and simpler. Concourse announced that they intend to deprecate the current `docker-image-resource` in the future.
@@ -326,4 +325,45 @@ jobs:
 -        build: docker-mongodb-exporter-git
 -        tag_as_latest: true #(tag_as_latest is default in the new registry-image resource)
 +        image: image/image.tar
+```
+
+## helm v3
+
+At the time of writing the [concourse-helm-resource](https://github.com/linkyard/concourse-helm-resource/issues/135) is not compatible with Concourse.
+There is however a [concourse-helm3-resource](https://github.com/Typositoire/concourse-helm3-resource) forked from that repository that you can use. We are using that resource and are contributing actively to that resource.
+
+Example usage:
+
+```yaml
+resource_types:
+  - name: helm
+    type: docker-image
+    source:
+      repository: typositoire/concourse-helm3-resource
+resources:
+  - name: example-helm
+    type: helm
+    source:
+      cluster_url: https://example.eks.amazonaws.com/
+      cluster_ca: ((HELM_CI.cluster_ca))
+      token: ((HELM_CI.token))
+      helm_history_max: 10
+jobs:
+  - name: example-deploy
+    plan:
+      - get: git-example-chart
+        trigger: true
+      - get: docker-example
+        params:
+          skip_download: true
+        trigger: true
+      - put: example-helm
+        params:
+          chart: git-example-chart/charts/example/
+          values: git-example-chart/charts/example/values.yaml
+          namespace: production
+          release: example
+          override_values:
+            - key: image.sha256
+              path: docker-example/digest
 ```

--- a/kubernetes/helm.md
+++ b/kubernetes/helm.md
@@ -14,6 +14,39 @@ This post from Helm explains how to set up helm v3 and how to migrate your confi
 
 - [Official documentation on the v2-v3 migration](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/)
 
+### How to migrate from Helm v2 to v3
+
+1. Migrate the releases from Helm2 to Helm3:
+   This can be done per namespace (remove dry-run to do it):
+
+   ```bash
+   NAMESPACE=<example>
+   for RELEASE in $(helm list --namespace $NAMESPACE | awk '{ print $1 }' | grep -v NAME); do helm3 2to3 convert $RELEASE --delete-v2-releases --dry-run; done
+   ```
+
+   or per deployment (remove dry-run to do it):
+
+   ```bash
+   helm3 2to3 convert <example> --delete-v2-releases --dry-run
+   ```
+
+   after that verify that all deployments are migrated to helm v3 and removed from helm v2:
+
+   ```bash
+   helm2 list | grep <example>
+   helm3 list -A | grep <example>
+   ```
+
+2. Patch your CICD integration
+   Now is a good moment to upgrade helm in your ci/cd system. If you are using Concourse: [you can use this guide](https://github.com/skyscrapers/documentation/blob/master/Concourse/README.md#helm-v3).
+
+3. Test your deployments
+   Test your deployment with Helm v3 to see if the chart works as expected:
+
+   ```bash
+   helm upgrade --install <example> ./charts/<example> --namespace <environment> --values ./charts/<example>_values.staging.yaml
+   ```
+
 ### Breaking changes
 
 Helm v2 charts are mostly compatible with version 3. There are however some things you need to be aware of:

--- a/kubernetes/helm.md
+++ b/kubernetes/helm.md
@@ -16,7 +16,7 @@ This post from Helm explains how to set up helm v3 and how to migrate your confi
 
 ### Breaking changes
 
-Helm v2 charts are mostly compatible with version 3. There are however some things you need to be aware from:
+Helm v2 charts are mostly compatible with version 3. There are however some things you need to be aware of:
 
 - [Tiller is removed](https://v3.helm.sh/docs/faq/#removal-of-tiller)
 Once the migration of all the deployments is done we will remove Tiller from our clusters.

--- a/kubernetes/helm.md
+++ b/kubernetes/helm.md
@@ -1,0 +1,35 @@
+# Helm
+
+## Setting up Helm v3
+
+- [Install the latest helm binary](https://github.com/helm/helm#install)
+  - Tip: if you want to have both helm v2 and helm v3: rename the binary of one or both versions.
+
+## migration from Helm v2 to v3
+
+In order to migrate from Helm v2 to v3 all deployments need to be migrated to their respective namespaces.
+This can be done with the [helm-2to3](https://github.com/helm/helm-2to3) plugin:
+
+This post from Helm explains how to set up helm v3 and how to migrate your config and the Helm v2 releases:
+
+- [Official documentation on the v2-v3 migration](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/)
+
+### Breaking changes
+
+Helm v2 charts are mostly compatible with version 3. There are however some things you need to be aware from:
+
+- [Tiller is removed](https://v3.helm.sh/docs/faq/#removal-of-tiller)
+Once the migration of all the deployments is done we will remove Tiller from our clusters.
+- [the way CRDs are handled by Helm has changed](https://helm.sh/docs/topics/charts/#custom-resource-definitions-crds)
+The way Helm 3 handles CRDs has been changed. They are now treated as special resources and are never upgraded by Helm once installed. The upgrade operation should be done by the cluster operators (admins) with extra care. Few things about this change:
+>
+> - CRDs should be put in the crds directory at the top level of chart directory.
+> - The YAML files in this directory cannot be templatized like any other resources from templates directory.
+> - The crd-install hook , which used to take care of installing CRD files from templates directory has been removed. If there are any files with crd-install annotation, then those are skipped by Helm.
+> - Files from crds directory are applied first before rendering the chart. These are never applied again if the CRDs exist in the cluster.
+
+- [Releases are now kept in their respective K8s Namespace](https://v3.helm.sh/docs/faq/#release-names-are-now-scoped-to-the-namespace)
+With this change its not needed anymore to add an environment parameter to your deployment. The names only need to be unique per K8s Namespace.
+Some of the helm commands have been updated to be more in line with other package managers.
+
+[Full helm 3 changelog](https://v3.helm.sh/docs/faq/#changes-since-helm-2)

--- a/kubernetes/helm.md
+++ b/kubernetes/helm.md
@@ -5,7 +5,7 @@
 - [Install the latest helm binary](https://github.com/helm/helm#install)
   - Tip: if you want to have both helm v2 and helm v3: rename the binary of one or both versions.
 
-## migration from Helm v2 to v3
+## Migration from Helm v2 to v3
 
 In order to migrate from Helm v2 to v3 all deployments need to be migrated to their respective namespaces.
 This can be done with the [helm-2to3](https://github.com/helm/helm-2to3) plugin:
@@ -20,7 +20,7 @@ Helm v2 charts are mostly compatible with version 3. There are however some thin
 
 - [Tiller is removed](https://v3.helm.sh/docs/faq/#removal-of-tiller)
 Once the migration of all the deployments is done we will remove Tiller from our clusters.
-- [the way CRDs are handled by Helm has changed](https://helm.sh/docs/topics/charts/#custom-resource-definitions-crds)
+- [The way CRDs are handled by Helm has changed](https://helm.sh/docs/topics/charts/#custom-resource-definitions-crds)
 The way Helm 3 handles CRDs has been changed. They are now treated as special resources and are never upgraded by Helm once installed. The upgrade operation should be done by the cluster operators (admins) with extra care. Few things about this change:
 >
 > - CRDs should be put in the crds directory at the top level of chart directory.
@@ -29,7 +29,7 @@ The way Helm 3 handles CRDs has been changed. They are now treated as special re
 > - Files from crds directory are applied first before rendering the chart. These are never applied again if the CRDs exist in the cluster.
 
 - [Releases are now kept in their respective K8s Namespace](https://v3.helm.sh/docs/faq/#release-names-are-now-scoped-to-the-namespace)
-With this change its not needed anymore to add an environment parameter to your deployment. The names only need to be unique per K8s Namespace.
+With this change it is not needed anymore to add an environment parameter to your deployment. The names only need to be unique per K8s Namespace.
 Some of the helm commands have been updated to be more in line with other package managers.
 
 [Full helm 3 changelog](https://v3.helm.sh/docs/faq/#changes-since-helm-2)


### PR DESCRIPTION
This PR adds documentation on:
- how to use helm3 in Concourse deployments
- how to migrate your personal helm2 configuration
- how to migrate deployments on your K8s cluster