### PR TITLE
Add support process documentation

### DIFF
--- a/support_process.md
+++ b/support_process.md
@@ -5,14 +5,13 @@
 We handle service requests via 3 main priority categories:
 
 ### Prio 1: Now (<30min)
-	- Only 24/7 incidents "production hampered" → Use your dedicated 24/7 escalation number, as mentioned in your documentation, to page the on-call engineer
+- Only 24/7 incidents "production hampered" → Use your dedicated 24/7 escalation number, as mentioned in your documentation, to page the on-call engineer
 ### Prio 2: Today
-	- You are stuck: breaking bugs, because feature X is not working or not implemented correctly
-	  → Create GitHub issue, notify via Slack `@help`
-	- Small guidance questions (where do I find..., how do I use...) → notify via Slack `@help`
+- You are stuck: breaking bugs, because feature X is not working or not implemented correctly → Create GitHub issue, notify via Slack `@help`
+- Small guidance questions (where do I find..., how do I use...) → notify via Slack `@help`
 ### Prio 3: To be planned
-	- All the rest (so everything that doesn't need to be resolved right now)
-	  → Handled via GitHub issue(s), weekly status call and/or planned meeting with your Lead Engineer
+- All the rest (so everything that doesn't need to be resolved right now)  → Handled via GitHub issue(s), weekly status call and/or planned meeting with your Lead Engineer.
+
   Examples:
   - Non-breaking bugs
   - New features / implementations

--- a/support_process.md
+++ b/support_process.md
@@ -1,0 +1,25 @@
+## Skyscrapers Support Process
+
+### Priorities
+
+We handle service requests via 3 main priority categories:
+
+- **Prio 1: Now (<30min)**: only 24/7 production incidents
+- **Prio 2: Today**
+- **Prio 3: To be planned**
+
+- **Prio 1: Now (<30min)**
+	- Only 24/7 incidents "production hampered" → Use the [escalation process](#escalation-process)
+- **Prio 2: Today**
+	- You are stuck: breaking bugs, because feature X is not working or not implemented correctly
+	  → Create GitHub issue, notify via Slack `@help`
+	- Small guidance questions (where do I find..., how do I use...) → notify via Slack `@help`
+- **Prio 3: To be planned**
+	- All the rest (so everything that doesn't need to be resolved right now)
+	  → Handled via GitHub issue(s), weekly status call and/or planned meeting with your Lead Engineer
+  Examples:
+  - Non-breaking bugs
+  - New features / implementations
+  - Queries for advice, design choices,...
+  - Queries for technical information
+  - Queries for non-technical information (contract, SLA, ...)

--- a/support_process.md
+++ b/support_process.md
@@ -1,20 +1,16 @@
-## Skyscrapers Support Process
+# Skyscrapers Support Process
 
-### Priorities
+## Priorities
 
 We handle service requests via 3 main priority categories:
 
-- **Prio 1: Now (<30min)**: only 24/7 production incidents
-- **Prio 2: Today**
-- **Prio 3: To be planned**
-
-- **Prio 1: Now (<30min)**
-	- Only 24/7 incidents "production hampered" → Use the [escalation process](#escalation-process)
-- **Prio 2: Today**
+### Prio 1: Now (<30min)
+	- Only 24/7 incidents "production hampered" → Use your dedicated 24/7 escalation number, as mentioned in your documentation, to page the on-call engineer
+### Prio 2: Today
 	- You are stuck: breaking bugs, because feature X is not working or not implemented correctly
 	  → Create GitHub issue, notify via Slack `@help`
 	- Small guidance questions (where do I find..., how do I use...) → notify via Slack `@help`
-- **Prio 3: To be planned**
+### Prio 3: To be planned
 	- All the rest (so everything that doesn't need to be resolved right now)
 	  → Handled via GitHub issue(s), weekly status call and/or planned meeting with your Lead Engineer
   Examples:
@@ -23,3 +19,4 @@ We handle service requests via 3 main priority categories:
   - Queries for advice, design choices,...
   - Queries for technical information
   - Queries for non-technical information (contract, SLA, ...)
+


### PR DESCRIPTION
unified documentation for our support process to be used for `@help` auto-response, based on the last updated format from here: https://www.notion.so/skyscrapers/Onboarding-of-customers-b289791fe31b44cda6023eb96ccdcd1b, with minor edits to be generic. 
